### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_validator.yml
+++ b/.github/workflows/pr_validator.yml
@@ -1,4 +1,6 @@
 name: Pull Request CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/tasiuskenways/Scalable-Ecommerce/security/code-scanning/1](https://github.com/tasiuskenways/Scalable-Ecommerce/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block at the root level of the workflow (above or below `name:`), which will apply the least privilege required to all jobs unless overridden. Since all jobs in this workflow only need to read repository contents and do not need to write to the repository, a minimal block with `contents: read` suffices. No additional privileges are necessary.

This change should be made at the top of `.github/workflows/pr_validator.yml`, ideally immediately after the `name:` field but before `on:`. There is no need to edit job-level blocks or steps. No new libraries or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR validation workflow permissions to use read-only access for repository contents, improving CI security posture.
  * Retained existing pull request triggers and branch filters; no changes to steps, jobs, or logic.
  * No impact on builds, tests, or deployment processes.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->